### PR TITLE
Fix TypeScript Error Preventing Build

### DIFF
--- a/packages/lib/src/services/converter.service.ts
+++ b/packages/lib/src/services/converter.service.ts
@@ -32,7 +32,7 @@ export class ConverterService {
     try {
       result = engine.renderFileSync(jsonData['MSH']['9']['3'], jsonData);
     } catch (e) {
-      if (e.message.includes('ENOENT: Failed to lookup')) {
+      if ((e as Error).message.includes('ENOENT: Failed to lookup')) {
         return Promise.reject({ type: 'ERR_UNSUPPORTED', error: e });
       }
       return Promise.reject({ type: 'ERR_TRANSLATE', error: e });


### PR DESCRIPTION
When running in Docker or locally the following error occurs:

```shell
src/services/converter.service.ts:35:11 - error TS2571: Object is of type 'unknown'.

35       if (e.message.includes('ENOENT: Failed to lookup')) {
             ~

Found 1 error.
```

This PR adds a type assertion to fix the TypeScript error so that the build can complete.

**References:**
* [Relevant SO post](https://stackoverflow.com/questions/54649465/how-to-do-try-catch-and-finally-statements-in-typescript)
* [Relevant TypeScript GitHub Issue](https://github.com/Microsoft/TypeScript/issues/20024)